### PR TITLE
ignore both em dash and en dash

### DIFF
--- a/check-zh-punctuation.py
+++ b/check-zh-punctuation.py
@@ -1,4 +1,4 @@
-import re, sys, os, zhon.hanzi
+import sys, os, zhon.hanzi
 
 # Check Chinese punctuation in English files.
 
@@ -7,6 +7,7 @@ def check_zh_punctuation(filename):
     lineNum = 0
     pos = []
     zh_punc = []
+    acceptable_punc = ['–','—'] # em dash and en dash
     flag = 0
 
     with open(filename, 'r') as file:
@@ -18,7 +19,7 @@ def check_zh_punctuation(filename):
 
             for char in line:
 
-                if char in zhon.hanzi.punctuation and char != '—' : # '—' does not count
+                if char in zhon.hanzi.punctuation and char not in acceptable_punc :
                     flag = 1
                     if count != 1:
                         pos.append(lineNum)


### PR DESCRIPTION
The current script ignores `em dash`, and I just found lots of false alarms caused by `en dash`. 
I believe both dashes are acceptable in English articles, so this PR tries to ignore them both. 

![image](https://user-images.githubusercontent.com/59654584/127597747-f4f4ebfc-be38-4d93-a88c-1927f5844cac.png)

Already tested the script locally. 

Signed-off-by: Ran <huangran@pingcap.com>